### PR TITLE
Fix for #7: Wait for wifi connected before initializing ESP-NOW

### DIFF
--- a/components/beethowen_receiver/beethowen_receiver_hub.h
+++ b/components/beethowen_receiver/beethowen_receiver_hub.h
@@ -28,6 +28,8 @@ namespace esphome
 
       void setup() override;
 
+      float get_setup_priority() const override { return setup_priority::AFTER_CONNECTION; }
+
     protected:
       uint16_t local_passkey_{0};
       bool send_data_ack_{false};


### PR DESCRIPTION
According to the docs, we need to wait until Wi-Fi is started before we initialize ESP-NOW:
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_now.html#initialization-and-deinitialization

Wi-Fi is started before ESP-NOW is initialized in the transmitter, but `esp_now_init()` is called too early in the receiver causing a boot loop. Changing the setup priority to `AFTER_CONNECTION` solves the issue.

Closes #7 